### PR TITLE
OS detection and download link update

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
 <script src="jquery.colorbox-min.js"></script>
 <script src="bootstrap/js/bootstrap.min.js"></script>
-<script src="js.js"></script>
+<script src="js.js?v=0"></script>
 <script src="yt.js"></script>
 </head>
 <body>
@@ -80,7 +80,7 @@
 			<div id="play-text">Play trailer.</div>
 	</div>
 	<div id="download">
-	<a href="https://github.com/nQuake/client-win32/raw/master/releases/nquake_installer-latest.exe" class="btn btn-warning left wider dl" title="Download nQuake" data-content="<b>Client:</b><br/>For <a href='https://github.com/nQuake/client-win32/raw/master/releases/nquake_installer-latest.exe' title='Download nQuake for Windows'>Windows</a>, <a href='https://github.com/nQuake/client-linux/raw/master/releases/nquake_installer-linux-latest.tar.gz' title='Download nQuake for Linux'>Linux</a> and <a href='https://github.com/nQuake/client-macosx/raw/master/releases/nquake_installer-macosx-latest.tar.gz' title='Download nQuake for OS X'>OS X</a>.<br/><br/>
+	<a href="https://github.com/nQuake/client-win32/raw/master/releases/nquake_installer-latest.exe" data-link-osx="https://github.com/nQuake/client-macosx/raw/master/releases/nquake_installer-macosx-latest.tar.gz" data-link-linux="https://github.com/nQuake/client-linux/raw/master/releases/nquake_installer-linux-latest.tar.gz" class="btn btn-warning left wider dl" id="download-link" title="Download nQuake" data-content="<b>Client:</b><br/>For <a href='https://github.com/nQuake/client-win32/raw/master/releases/nquake_installer-latest.exe' title='Download nQuake for Windows'>Windows</a>, <a href='https://github.com/nQuake/client-linux/raw/master/releases/nquake_installer-linux-latest.tar.gz' title='Download nQuake for Linux'>Linux</a> and <a href='https://github.com/nQuake/client-macosx/raw/master/releases/nquake_installer-macosx-latest.tar.gz' title='Download nQuake for OS X'>OS X</a>.<br/><br/>
 	<b>Server:</b><br/>For <a href='https://github.com/nQuake/server-win32/raw/master/releases/nquakesv_installer-latest.exe' title='Download nQuake server for Windows'>Windows</a> and <a href='https://github.com/nQuake/server-linux/raw/master/releases/nquakesv_installer-linux-latest.tar.gz' title='Download nQuake server for Linux'>Linux</a>.">
 	<i class="icon-circle-arrow-down"></i> Download</a>
 	<a href="images/nquake_default_config.jpg" data-content="Check out the <a href='images/nquake_default_config.jpg'>default nQuake config bindings</a>." title="Default nQuake config" class="btn btn-info left wider"><i class="icon-picture"></i> Config overview</a>

--- a/js.js
+++ b/js.js
@@ -38,6 +38,17 @@ jQuery("#video").tubeplayer({
   onQualityChange: function(quality){}, // a function callback for when the quality of a video is determined
 });
 
+  //os detection and download link update
+  var downloadLink = $('#download-link');
+  var currentPlatform = navigator.platform;
+  if (currentPlatform.indexOf('Win') == 0) {
+      //no change needed
+  } else if (currentPlatform.indexOf('Mac') == 0) {
+      downloadLink.attr('href', downloadLink.data('link-osx'));
+  } else {
+      downloadLink.attr('href', downloadLink.data('link-linux'));
+  }
+
 });
 
 $(function(){


### PR DESCRIPTION
Currently, download link defaults to the `.exe` installer. This checks **navigator.platform** property and adjusts the link according to, if it starts with anything other than **Win**. I have added `?v=0` to  `js.js` script src just in case user may have cached the file already.